### PR TITLE
changed the path of colors.less

### DIFF
--- a/styles/languages.less
+++ b/styles/languages.less
@@ -1,4 +1,4 @@
-@import 'colors';
+@import '@{colors-path}/colors';
 @import (less) "@{language-bower-path}/hint.css/hint.css";
 
 #list-of-languages > p > a {


### PR DESCRIPTION
Language.less refers to 'colors' to look at current path which at the build moment is /bower_components/webmaker-language-picker/styles, however colors.less resides in /public/stylesheets/. While Travis tests Thimble, the LESSLINT throws an error that can't find 'colors.less'. You can see closely here: https://bugzilla.mozilla.org/show_bug.cgi?id=916944 at the Travis build. I'm not sure if changed path will impact other things, but it needs to be changed in order to perform LESS linting for Thimble. Please consider it. Thanks
