### PR TITLE
updated with variable to specify colors path

### DIFF
--- a/styles/languages.less
+++ b/styles/languages.less
@@ -1,4 +1,4 @@
-@import 'colors';
+@import '@{colors-path}/colors';
 @import (less) "@{language-bower-path}/hint.css/hint.css";
 @import (less) "@{language-bower-path}/selectize/dist/css/selectize.default.css";
 


### PR DESCRIPTION
As agreed previously, I've added color-path variable to handle LESS linting. Patches are ready to be merged:
https://github.com/mozilla/goggles.webmaker.org/pull/116
https://github.com/mozilla/webmaker.org/pull/632
https://github.com/mozilla/popcorn.webmaker.org/pull/509
https://github.com/mozilla/thimble.webmaker.org/pull/387
Currently they use 17 version of webmaker-language-picker, but once this PR will be merged, I will update all these PR to the next version (which is will be 20 if I'm not mistaken).
