### PR TITLE
Bug 1039055 - Add language picker to Maker Party site

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "listjs": "git://github.com/javve/list.js.git#~1.0.0",
     "selectize": "0.9.0"
   },
-  "version": "0.0.24",
+  "version": "0.0.25",
   "homepage": "https://github.com/mozilla/webmaker-language-picker",
   "authors": [
     "Ali Al Dallal <ali@alicoding.com>"

--- a/js/languages.js
+++ b/js/languages.js
@@ -19,7 +19,7 @@ define(['jquery', 'list', 'fuzzySearch', 'analytics'], function ($, List, Fuzzy,
       //   that.langRedirector($(this).data().value);
       // });
 
-      // switching to `change` handler seems to work on Chrome/Firefox/Safari
+      // switching to use the `change` event handler seems to work on Chrome/Firefox/Safari
       $('select[name=supportedLocales]').change(function(){
         analytics.event('Language Picked', {
           label: $(this).val()


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1039055

Had to make the following changes in order for this to work on the Maker Party site.   The makerparty repo is current referencing to my forked version of this module: https://github.com/mozilla/makerparty/blob/develop/bower.json#L21

Not sure if this PR should be merged or we should create a new repo (under Github Mozilla) in case we need to hack this module further in the future.
